### PR TITLE
Discarding one-word sentences

### DIFF
--- a/src/main/scala/edu/knowitall/openie/OpenIE.scala
+++ b/src/main/scala/edu/knowitall/openie/OpenIE.scala
@@ -183,28 +183,30 @@ class OpenIE(parser: DependencyParser = new ClearParser(), srl: Srl = new ClearS
     }
     else {
     for (newSentence <- newSentences) {
-      //System.err.println("New: " + newSentence)
-      val cleaned = clean(newSentence)
-      //System.err.println("Cleaned: " + cleaned)
-      val chunked = chunker(cleaned) map MorphaStemmer.lemmatizePostaggedToken
-      //System.err.println("Chunked: " + chunked)
-      val parsed = parser(cleaned)
-      //System.err.println("Parsed: " + parsed)
-      
-      // run extractors
-      val srlExtrs: Seq[SrlExtractionInstance] =
-        if (isTriples) srlie(parsed).flatMap(_.triplize())
-        else srlie(parsed)
-      //System.err.println("srlExtrs: " + srlExtrs)
-      val relnounExtrs = relnoun(chunked)
-      //System.err.println("relExtrs: " + relnounExtrs)
-      val onreExtrs = MayIHelpYou.runMe(parsed).asScala.keys;
-      //System.err.println("onreExtrs: " + onreExtrs)
-      
-      val extrs = (srlExtrs map convertSrl) ++ (relnounExtrs map convertRelnoun) ++ (onreExtrs map convertOnre)
-      
-      //System.err.println("Extrs: " + extrs)
-      totalExtrs = totalExtrs ++ extrs
+      if (newSentence.split(" ").length > 1) {
+        //System.err.println("New: " + newSentence)
+        val cleaned = clean(newSentence)
+        //System.err.println("Cleaned: " + cleaned)
+        val chunked = chunker(cleaned) map MorphaStemmer.lemmatizePostaggedToken
+        //System.err.println("Chunked: " + chunked)
+        val parsed = parser(cleaned)
+        //System.err.println("Parsed: " + parsed)
+        
+        // run extractors
+        val srlExtrs: Seq[SrlExtractionInstance] =
+          if (isTriples) srlie(parsed).flatMap(_.triplize())
+          else srlie(parsed)
+        //System.err.println("srlExtrs: " + srlExtrs)
+        val relnounExtrs = relnoun(chunked)
+        //System.err.println("relExtrs: " + relnounExtrs)
+        val onreExtrs = MayIHelpYou.runMe(parsed).asScala.keys;
+        //System.err.println("onreExtrs: " + onreExtrs)
+        
+        val extrs = (srlExtrs map convertSrl) ++ (relnounExtrs map convertRelnoun) ++ (onreExtrs map convertOnre)
+        
+        //System.err.println("Extrs: " + extrs)
+        totalExtrs = totalExtrs ++ extrs
+      }
     }}
     
     removeDuplicateExtractions(totalExtrs)


### PR DESCRIPTION
Sometimes CALM returns one-word sentences, which gives an error in BONIE as Clear parser throws error on one-word sentences.